### PR TITLE
Enable RSS Feed for Posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ collections:
 remote_theme: jekyll/minima
 plugins:
   - jekyll-seo-tag
-  # - jekyll-feed
+  - jekyll-feed
   - jekyll-remote-theme
 
 # include posts with a future date

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, user-scalable=yes"
     />
+    <link rel="alternate" type="application/rss+xml" title="Galway IT Meetup" href="/feed.xml"/>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"


### PR DESCRIPTION
Makes it easy for people to subscribe to the RSS feed for the website and keep up to date with blog posts and event postings --- especially useful for boomers like me who aren't active on social media.

Shouldn't affect your existing build/deploy process: same commands as usual to install Ruby dependencies etc.